### PR TITLE
Hotfix 1.7.5.1

### DIFF
--- a/js/ezMisc.js
+++ b/js/ezMisc.js
@@ -339,6 +339,10 @@ function setTheme(name) {
   var html = document.documentElement;
   html.setAttribute('data-theme', name);
   themeBadge.textContent = name;
+  var elements = document.getElementsByClassName('ezGitPart');
+  if (elements.length > 0) {
+    cleanEzGitPartsBackground(elements);
+  }
   loadActiveTheme();
 }
 
@@ -364,3 +368,9 @@ $('#themesModal').on('shown.bs.modal', function() {
 $('#themesModal').on('hidden.bs.modal', function() {
   activeTheme.style.border = '1px solid black';
 });
+
+function cleanEzGitPartsBackground(elements) {
+  elements.forEach(element => {
+    element.style.removeProperty('background-color');
+  });
+}


### PR DESCRIPTION
Hotfix targetting themes problem:

```
When using highlight system to refer to element and then 
changing theme, previously highlighted ezGitPart background 
color is improper.
```